### PR TITLE
Ammend `getStaticPackages()` to use `PackageInterface`

### DIFF
--- a/src/StaticsMergerPlugin.php
+++ b/src/StaticsMergerPlugin.php
@@ -261,7 +261,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
     {
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getPackages();
 
-        return array_filter($packages, function (Package $package) {
+        return array_filter($packages, function (PackageInterface $package) {
             return $package->getType() == static::PACKAGE_TYPE && $this->getStaticMaps($package->getName());
         });
     }


### PR DESCRIPTION
When an instance of `\Composer\Package\AliasPackage` is found `getStaticPackages()` throws an exception.
All packages are required to implement `\Composer\Package\PackageInterface` so it makes more sense for the closure
arguement to require that instead.
