### PR TITLE
Ammend `getStaticPackages()` to use `PackageInterface`

### DIFF
--- a/src/StaticsMergerPlugin.php
+++ b/src/StaticsMergerPlugin.php
@@ -261,7 +261,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
     {
         $packages = $this->composer->getRepositoryManager()->getLocalRepository()->getPackages();
 
-        return array_filter($packages, function (Package $package) {
+        return array_filter($packages, function (PackageInterface $package) {
             return $package->getType() == static::PACKAGE_TYPE && $this->getStaticMaps($package->getName());
         });
     }

--- a/test/StaticsMergerPluginTest.php
+++ b/test/StaticsMergerPluginTest.php
@@ -2,6 +2,7 @@
 
 namespace Jh\StaticsMergerTest;
 
+use Composer\Package\AliasPackage;
 use Composer\Package\Package;
 use Composer\Package\PackageInterface;
 use Composer\Package\RootPackage;
@@ -973,5 +974,22 @@ class StaticsMergerPluginTest extends \PHPUnit_Framework_TestCase
             // Can stay in same dir
             array('same/dir/assets/test',     'same/dir/assets/file',         './file')
         );
+    }
+
+    public function testGetStaticPackagesAllowsAliasPackageInstance()
+    {
+        $this->createRootPackage();
+        $staticPackage = $this->createStaticPackage();
+
+        $truePackage = new Package("package/package", "1.0.0", "package/package");
+        $aliasPackage = new AliasPackage($truePackage, '1.1.1', 'alias/package');
+
+        $this->localRepository->addPackage($aliasPackage);
+        $this->localRepository->addPackage($staticPackage);
+
+        $this->activatePlugin();
+        $staticPackages = $this->plugin->getStaticPackages();
+
+        $this->assertNotEmpty($staticPackages);
     }
 }


### PR DESCRIPTION
When an instance of `\Composer\Package\AliasPackage` is found `getStaticPackages()` throws an exception.
All packages are required to implement `\Composer\Package\PackageInterface` so it makes more sense for the closure
arguement to require that instead.
